### PR TITLE
display the build summary step label as an inline block

### DIFF
--- a/www/react-base/src/components/BuildSummary/BuildSummary.scss
+++ b/www/react-base/src/components/BuildSummary/BuildSummary.scss
@@ -38,6 +38,10 @@
 .bb-build-summary-step-line {
   position:relative;
 
+  .bb-build-summary-step-label {
+    display: inline-block;
+  }
+  
   &.list-group-item.bb-anchor-target {
     border: 2px solid #ffff00;
   }

--- a/www/react-base/src/components/BuildSummary/BuildSummary.tsx
+++ b/www/react-base/src/components/BuildSummary/BuildSummary.tsx
@@ -202,7 +202,7 @@ const BuildSummaryStepLine = observer(({build, step, logs, parentFullDisplay}: B
 
   return (
     <li key={step.id} className="bb-build-summary-step-line list-group-item" id={`bb-step-${step.number}`}>
-      <div onClick={() => setFullDisplay(!fullDisplay)}>
+      <div className="bb-build-summary-step-label" onClick={() => setFullDisplay(!fullDisplay)}>
         <AnchorLink className="bb-build-summary-step-anchor-link"
                     anchor={`bb-step-${step.number}`}>
           #


### PR DESCRIPTION
This PR fix the following issue:
The build summary requests UI is broken when a line break occurs in the step's build summary.

_Screenshot of the issue_
![ui broken on line break](https://github.com/buildbot/buildbot/assets/12350021/f781fa36-11bc-4e6c-925e-5577988acc70)

_Screenshot with the fix_
![issue-build-bot-fixed](https://github.com/buildbot/buildbot/assets/12350021/9559c3cf-c00e-43f9-8059-84105fb88767)

## Contributor Checklist:

* [not_needed ] I have updated the unit tests
* [not_needed] I have created a file in the `newsfragments` directory (and read the `README.txt` in that directory)
* [not_needed ] I have updated the appropriate documentation
