### PR TITLE
Frontend: clean step line

### DIFF
--- a/www/react-base/src/components/BuildSummary/BuildSummary.scss
+++ b/www/react-base/src/components/BuildSummary/BuildSummary.scss
@@ -11,7 +11,9 @@
     border-top-right-radius: 3px;
   }
 
-  .bb-build-summary-details,
+  .bb-build-summary-details{
+    text-align: left;
+  }
   .bb-build-summary-time {
     float: right;
   }

--- a/www/react-base/src/components/BuildSummary/BuildSummary.tsx
+++ b/www/react-base/src/components/BuildSummary/BuildSummary.tsx
@@ -130,9 +130,7 @@ const BuildSummaryStepLine = observer(({build, step, logs, parentFullDisplay}: B
 
     return (
       <span className="bb-build-summary-time">
-          {stepDurationFormatWithLocks(step, now)}
-        &nbsp;
-        {step.state_string}
+        {stepDurationFormatWithLocks(step, now)}
         </span>
     );
   }
@@ -212,6 +210,11 @@ const BuildSummaryStepLine = observer(({build, step, logs, parentFullDisplay}: B
         {maybeRenderArrowExpander()}
         &nbsp;
         {step.name}
+        &nbsp;&nbsp;
+        {/* state_string disabled, as it is, it's really overloading the step line with no real interest IMO */}
+        {/*{step.state_string}*/}
+      </div>
+      <div className="bb-build-summary-time">
         {renderState()}
         {maybeRenderPendingBuildCount()}
       </div>


### PR DESCRIPTION
Remove state_string, I feel it overloads the step line for no real purpose
Align step duration right so we have a spacing consistency with step name left and duration right
Left uses the pr, right is vanilla.
Pr is fork side for now because I know I want this but I'm not sure bb guys appreciate the change.
![image](https://github.com/dontnod/fork-buildbot/assets/20304337/03bc473f-23d5-4989-809c-1ceb7274f706)
