### PR TITLE
[4.x] www: fix display build summary label 

### DIFF
--- a/www/react-base/src/components/BuildSummary/BuildSummary.scss
+++ b/www/react-base/src/components/BuildSummary/BuildSummary.scss
@@ -42,6 +42,20 @@
     padding: 0.375rem 1rem;
   }
 
+  .bb-build-summary-step-label {
+    display: flex;
+    align-items: center;
+
+    > *  {
+      flex-shrink: 0;
+    }
+
+    .bb-build-summary-time {
+      flex-shrink: 1;
+      margin-left: auto;
+    }
+  }
+
   &.list-group-item.bb-anchor-target {
     border: 2px solid #ffff00;
   }

--- a/www/react-base/src/components/BuildSummary/BuildSummary.tsx
+++ b/www/react-base/src/components/BuildSummary/BuildSummary.tsx
@@ -204,7 +204,7 @@ const BuildSummaryStepLine = observer(({build, step, logs, parentFullDisplay}: B
 
   return (
     <li key={step.id} className="bb-build-summary-step-line list-group-item" id={`bb-step-${step.number}`}>
-      <div onClick={() => setFullDisplay(!fullDisplay)}>
+      <div className="bb-build-summary-step-label" onClick={() => setFullDisplay(!fullDisplay)}>
         <AnchorLink className="bb-build-summary-step-anchor-link"
                     anchor={`bb-step-${step.number}`}>
           #


### PR DESCRIPTION
This PR fixes an issue introduced by https://github.com/dontnod/fork-buildbot/pull/5 where the build time wouldn't be align anymore on the right.

*Screenshot with the new fix*
![Screenshot with the new fix](https://github.com/dontnod/fork-buildbot/assets/12350021/3ffcbccf-23e5-4470-8afb-bf10c7678fbb)

*Screenshot with the previous regression of https://github.com/dontnod/fork-buildbot/pull/5*
![Screenshot with the previous regression](https://github.com/dontnod/fork-buildbot/assets/12350021/2c2c88eb-0901-494b-902c-67e2f7d15bd8)
