### PR TITLE
 [4.x] BuildSummmary default to OnlyNotSuccess

### DIFF
--- a/www/react-base/src/components/BuildSummary/BuildSummary.tsx
+++ b/www/react-base/src/components/BuildSummary/BuildSummary.tsx
@@ -237,7 +237,7 @@ export const BuildSummary = observer(({build, parentBuild, parentRelationship,
   const logsQuery = useDataApiQuery(() => stepsQuery.getRelated(step => step.getLogs()));
 
   const [detailLevel, setDetailLevel] =
-    useState<DetailLevel>(condensed ? DetailLevel.None : DetailLevel.Everything);
+    useState<DetailLevel>(condensed ? DetailLevel.OnlyNotSuccess : DetailLevel.Everything);
 
   const builder = builderQuery.getNthOrNull(0);
   const parentBuilder = builderBuilderQuery.getNthOrNull(0);


### PR DESCRIPTION
This change the default behavior of steps to expand logs for steps with non-success status